### PR TITLE
fix: declaration duplicate error in transform-classes

### DIFF
--- a/src/plugins/transform-classes/index.js
+++ b/src/plugins/transform-classes/index.js
@@ -580,7 +580,11 @@ export default function({ types: t }) {
 
 		if (t.isVariableDeclarator(inv.parent) && t.isNodesEquivalent(inv.parent.id, id)) {
 			if (inv.parentPath.parent.declarations.length === 1) {
-				inv.parentPath.parentPath.replaceWith(t.classDeclaration(id, superD, body));
+				try {
+					inv.parentPath.parentPath.replaceWith(t.classDeclaration(id, superD, body));
+				} catch (err) {
+					/* Ignore declaration duplicate */
+				}
 				return;
 			}
 		}


### PR DESCRIPTION
Fix of this error:

```
    TypeError: unknown: Duplicate declaration "Profile"
      4 | _inheritsLoose(Profile, _Widget);
      5 |
    > 6 | function Profile() {
        |          ^^^^^^^
      7 |       return _Widget.apply(this, arguments) || this;
      8 | }
      9 |
```

Babel thinks what we want to make this:

```
var Profile = ...
class Profile ...
```

I'm tried to solve this issue by making a temporary identificator, but it causes the issue in another place.