### PR TITLE
Fix destructing

### DIFF
--- a/src/plugins/transform-destructuring/index.js
+++ b/src/plugins/transform-destructuring/index.js
@@ -321,6 +321,10 @@ export default ({ types: t }) => {
 						}
 					} else {
 						// Bailout: there is unknown computed property access into the object.
+						if (pattern.length) {
+							break;
+						}
+
 						return;
 					}
 				}

--- a/src/plugins/transform-destructuring/index.test.js
+++ b/src/plugins/transform-destructuring/index.test.js
@@ -112,13 +112,26 @@ describe('transform-destructuring', () => {
 			let o = q[t];
 		`)
 		).toMatchInlineSnapshot(`
-		"const q = {
-			a: 1,
-			b: 2
-		};
-		let t = window.t;
-		let o = q[t];"
-	`);
+			"const q = {
+				a: 1,
+				b: 2
+			};
+			let t = window.t;
+			let o = q[t];"
+		`);
+
+		expect(
+			b(dent`
+				var keys = [];
+				var i = keys.length;
+				var opt = keys[i];
+			`)
+		).toMatchInlineSnapshot(`
+			"var {
+				length: i
+			} = [];
+			var opt = keys[i];"
+		`);
 	});
 
 	describe('array-like destructuring', () => {


### PR DESCRIPTION
Behavior before fix:
```
var keys = [];
var i = keys.length;
var opt = keys[i];
->
var keys = [];
var opt = keys[i];
```